### PR TITLE
Updated for Swift 3 and Xcode 8

### DIFF
--- a/SwiftyExpandingCells/AppDelegate.swift
+++ b/SwiftyExpandingCells/AppDelegate.swift
@@ -13,34 +13,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
-        UINavigationBar.appearance().tintColor = UIColor.whiteColor()
+        UINavigationBar.appearance().tintColor = UIColor.white
         UINavigationBar.appearance().barTintColor = UIColor(red: 0.0, green: 155.0/255.0, blue: 1.0, alpha: 1.0)
-        UINavigationBar.appearance().titleTextAttributes = [NSForegroundColorAttributeName : UIColor.whiteColor()]
+        UINavigationBar.appearance().titleTextAttributes = [NSForegroundColorAttributeName : UIColor.white]
         
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/SwiftyExpandingCells/DetailVC.swift
+++ b/SwiftyExpandingCells/DetailVC.swift
@@ -20,7 +20,7 @@ class DetailVC: UIViewController {
     }
     
     func setup() {
-        self.view.frame.origin.y = UIApplication.sharedApplication().statusBarFrame.size.height
+        self.view.frame.origin.y = UIApplication.shared.statusBarFrame.size.height
         
         if let brand = self.brand {
             self.title = brand.name

--- a/SwiftyExpandingCells/Libs/FontAwesome/FontAwesome.swift
+++ b/SwiftyExpandingCells/Libs/FontAwesome/FontAwesome.swift
@@ -24,43 +24,41 @@ import UIKit
 import CoreText
 
 private class FontLoader {
-    class func loadFont(name: String) {
-        let bundle = NSBundle(forClass: FontLoader.self)
-        var fontURL = NSURL()
+    class func loadFont(_ name: String) {
+        let bundle = Bundle(for: FontLoader.self)
+        var fontURL: URL!
         let identifier = bundle.bundleIdentifier
 
         if identifier?.hasPrefix("org.cocoapods") == true {
             // If this framework is added using CocoaPods, resources is placed under a subdirectory
-            fontURL = bundle.URLForResource(name, withExtension: "otf", subdirectory: "FontAwesome.swift.bundle")!
+            fontURL = bundle.url(forResource: name, withExtension: "otf", subdirectory: "FontAwesome.swift.bundle")!
         } else {
-            fontURL = bundle.URLForResource(name, withExtension: "otf")!
+            fontURL = bundle.url(forResource: name, withExtension: "otf")!
         }
 
-        let data = NSData(contentsOfURL: fontURL)!
+        let data = try! Data(contentsOf: fontURL)
 
-        let provider = CGDataProviderCreateWithCFData(data)
-        let font = CGFontCreateWithDataProvider(provider)!
+        let provider = CGDataProvider(data: data as! CFData)
+        let font = CGFont(provider!)
 
         var error: Unmanaged<CFError>?
         if !CTFontManagerRegisterGraphicsFont(font, &error) {
-            let errorDescription: CFStringRef = CFErrorCopyDescription(error!.takeUnretainedValue())
+            let errorDescription: CFString = CFErrorCopyDescription(error!.takeUnretainedValue())
             let nsError = error!.takeUnretainedValue() as AnyObject as! NSError
-            NSException(name: NSInternalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
+            NSException(name: NSExceptionName.internalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
         }
     }
 }
 
 public extension UIFont {
-    public class func fontAwesomeOfSize(fontSize: CGFloat) -> UIFont {
+    public class func fontAwesomeOfSize(_ fontSize: CGFloat) -> UIFont {
         struct Static {
-            static var onceToken : dispatch_once_t = 0
+            static var onceToken : Int = 0
         }
 
         let name = "FontAwesome"
-        if (UIFont.fontNamesForFamilyName(name).count == 0) {
-            dispatch_once(&Static.onceToken) {
+        if (UIFont.fontNames(forFamilyName: name).count == 0) {
                 FontLoader.loadFont(name)
-            }
         }
 
         return UIFont(name: name, size: fontSize)!
@@ -68,27 +66,27 @@ public extension UIFont {
 }
 
 public extension String {
-    public static func fontAwesomeIconWithName(name: FontAwesome) -> String {
-        return name.rawValue.substringToIndex(name.rawValue.startIndex.advancedBy(1))
+    public static func fontAwesomeIconWithName(_ name: FontAwesome) -> String {
+        return name.rawValue.substring(to: name.rawValue.characters.index(name.rawValue.startIndex, offsetBy: 1))
     }
 }
 
 public extension UIImage {
-    public static func fontAwesomeIconWithName(name: FontAwesome, textColor: UIColor, size: CGSize) -> UIImage {
+    public static func fontAwesomeIconWithName(_ name: FontAwesome, textColor: UIColor, size: CGSize) -> UIImage {
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineBreakMode = NSLineBreakMode.ByWordWrapping
-        paragraph.alignment = .Center
+        paragraph.lineBreakMode = NSLineBreakMode.byWordWrapping
+        paragraph.alignment = .center
         let attributedString = NSAttributedString(string: String.fontAwesomeIconWithName(name) as String, attributes: [NSFontAttributeName: UIFont.fontAwesomeOfSize(max(size.width, size.height)), NSForegroundColorAttributeName: textColor, NSParagraphStyleAttributeName:paragraph])
         let size = sizeOfAttributeString(attributedString, maxWidth: size.width)
         UIGraphicsBeginImageContextWithOptions(size, false , 0.0)
-        attributedString.drawInRect(CGRectMake(0, 0, size.width, size.height))
+        attributedString.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return image
+        return image!
     }
 }
 
-func sizeOfAttributeString(str: NSAttributedString, maxWidth: CGFloat) -> CGSize {
-    let size = str.boundingRectWithSize(CGSizeMake(maxWidth, 1000), options:(NSStringDrawingOptions.UsesLineFragmentOrigin), context:nil).size
+func sizeOfAttributeString(_ str: NSAttributedString, maxWidth: CGFloat) -> CGSize {
+    let size = str.boundingRect(with: CGSize(width: maxWidth, height: 1000), options:(NSStringDrawingOptions.usesLineFragmentOrigin), context:nil).size
     return size
 }

--- a/SwiftyExpandingCells/Libs/SegueHandlerType/SegueHandlerType.swift
+++ b/SwiftyExpandingCells/Libs/SegueHandlerType/SegueHandlerType.swift
@@ -54,23 +54,23 @@ public extension SegueHandlerType where Self: ViewController, SegueIdentifier.Ra
         method that takes in a `SegueIdentifier` enum parameter rather than a
         `String`.
     */
-    func performSegueWithIdentifier(segueIdentifier: SegueIdentifier, sender: AnyObject?) {
-        performSegueWithIdentifier(segueIdentifier.rawValue, sender: sender)
+    func performSegueWithIdentifier(_ segueIdentifier: SegueIdentifier, sender: AnyObject?) {
+        performSegue(withIdentifier: segueIdentifier.rawValue, sender: sender)
     }
 
     /**
         A convenience method to map a `StoryboardSegue` to the  segue identifier
         enum that it represents.
     */
-    func segueIdentifierForSegue(segue: StoryboardSegue) -> SegueIdentifier {
+    func segueIdentifierForSegue(_ segue: StoryboardSegue) -> SegueIdentifier {
         /*
             Map the segue identifier's string to an enum. It's a programmer error
             if a segue identifier string that's provided doesn't map to one of the
             raw representable values (most likely enum cases).
         */
         guard let identifier = segue.identifier,
-                  segueIdentifier = SegueIdentifier(rawValue: identifier) else {
-            fatalError("Couldn't handle segue identifier \(segue.identifier) for view controller of type \(self.dynamicType).")
+                  let segueIdentifier = SegueIdentifier(rawValue: identifier) else {
+            fatalError("Couldn't handle segue identifier \(segue.identifier) for view controller of type \(type(of: self)).")
         }
 
         return segueIdentifier

--- a/SwiftyExpandingCells/MasterVC.swift
+++ b/SwiftyExpandingCells/MasterVC.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHandlerType {
     let transtition = SwiftyExpandingTransition()
-    var selectedCellFrame = CGRectZero
+    var selectedCellFrame = CGRect(x: 0, y: 0, width: 0, height: 0)
     var selectedBrand: Brand?
     
     enum SegueIdentifier: String {
@@ -21,11 +21,11 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
         super.viewDidLoad()
     }
     
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return BrandManager.sharedInstance.brands.count
     }
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let brand = BrandManager.sharedInstance.brands[indexPath.row]
         
         if let cell = tableView.dequeueReusableCellWithIdentifier("brand") {
@@ -38,14 +38,14 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
         return UITableViewCell()
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         self.selectedCellFrame = tableView.convertRect(tableView.cellForRowAtIndexPath(indexPath)!.frame, toView: tableView.superview)
         self.selectedBrand = BrandManager.sharedInstance.brands[indexPath.row]
         
         self.performSegueWithIdentifier(.DetailVC , sender: nil)
     }
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         switch segueIdentifierForSegue(segue) {
             case .DetailVC:
                 let vc = segue.destinationViewController as! DetailVC
@@ -55,7 +55,7 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
         }
     }
 
-    func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationControllerOperation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         
         if operation == UINavigationControllerOperation.Push {
             transtition.operation = UINavigationControllerOperation.Push

--- a/SwiftyExpandingCells/MasterVC.swift
+++ b/SwiftyExpandingCells/MasterVC.swift
@@ -28,7 +28,7 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let brand = BrandManager.sharedInstance.brands[indexPath.row]
         
-        if let cell = tableView.dequeueReusableCellWithIdentifier("brand") {
+        if let cell = tableView.dequeueReusableCell(withIdentifier: "brand") {
             cell.textLabel?.text = brand.iconText
             cell.detailTextLabel?.text = brand.name
             
@@ -39,7 +39,7 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        self.selectedCellFrame = tableView.convertRect(tableView.cellForRowAtIndexPath(indexPath)!.frame, toView: tableView.superview)
+        self.selectedCellFrame = tableView.convert(tableView.cellForRow(at: indexPath)!.frame, to: tableView.superview)
         self.selectedBrand = BrandManager.sharedInstance.brands[indexPath.row]
         
         self.performSegueWithIdentifier(.DetailVC , sender: nil)
@@ -48,7 +48,7 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         switch segueIdentifierForSegue(segue) {
             case .DetailVC:
-                let vc = segue.destinationViewController as! DetailVC
+                let vc = segue.destination as! DetailVC
                     vc.brand = self.selectedBrand
                 
                 self.navigationController?.delegate = self
@@ -57,16 +57,16 @@ class MasterVC: UITableViewController, UINavigationControllerDelegate, SegueHand
 
     func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationControllerOperation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         
-        if operation == UINavigationControllerOperation.Push {
-            transtition.operation = UINavigationControllerOperation.Push
+        if operation == UINavigationControllerOperation.push {
+            transtition.operation = UINavigationControllerOperation.push
             transtition.duration = 0.40
             transtition.selectedCellFrame = self.selectedCellFrame
             
             return transtition
         }
         
-        if operation == UINavigationControllerOperation.Pop {
-            transtition.operation = UINavigationControllerOperation.Pop
+        if operation == UINavigationControllerOperation.pop {
+            transtition.operation = UINavigationControllerOperation.pop
             transtition.duration = 0.20
             
             return transtition

--- a/SwiftyExpandingCells/Src/SwiftyExpandingTransition.swift
+++ b/SwiftyExpandingCells/Src/SwiftyExpandingTransition.swift
@@ -15,44 +15,44 @@ class SwiftyExpandingTransition: NSObject, UIViewControllerAnimatedTransitioning
 
     var imageViewTop: UIImageView?
     var imageViewBottom: UIImageView?
-    var duration: NSTimeInterval = 0
-    var selectedCellFrame = CGRectZero
+    var duration: TimeInterval = 0
+    var selectedCellFrame = CGRect(x: 0, y: 0, width: 0, height: 0)
 
-    func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return self.duration
     }
 
-    func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-        let sourceVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)!
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let sourceVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from)!
         let sourceView = sourceVC.view
 
-        let destinationVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)!
+        let destinationVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)!
         let destinationView = destinationVC.view
 
-        let container = transitionContext.containerView()!
+        let container = transitionContext.containerView
 
-        let initialFrame = transitionContext.initialFrameForViewController(sourceVC)
-        let finalFrame = transitionContext.finalFrameForViewController(destinationVC)
+        let initialFrame = transitionContext.initialFrame(for: sourceVC)
+        let finalFrame = transitionContext.finalFrame(for: destinationVC)
 
         // must set final frame, because it could be (0.0, 64.0, 768.0, 960.0)
         // and the destinationView frame could be (0 0; 768 1024)
-        destinationView.frame = finalFrame
+        destinationView?.frame = finalFrame
 
-        self.selectedCellFrame = CGRectMake(self.selectedCellFrame.origin.x, self.selectedCellFrame.origin.y + self.selectedCellFrame.height, self.selectedCellFrame.width, self.selectedCellFrame.height)
+        self.selectedCellFrame = CGRect(x:self.selectedCellFrame.origin.x, y: self.selectedCellFrame.origin.y + self.selectedCellFrame.height, width: self.selectedCellFrame.width, height: self.selectedCellFrame.height)
 
         var snapShot = UIImage()
-        let bounds = CGRectMake(0, 0, sourceView.bounds.size.width, sourceView.bounds.size.height)
+        let bounds = CGRect(x: 0, y: 0, width: (sourceView?.bounds.size.width)!, height: (sourceView?.bounds.size.height)!)
 
-        if self.operation == UINavigationControllerOperation.Push {
-            UIGraphicsBeginImageContextWithOptions(sourceView.bounds.size, true, 0)
+        if self.operation == UINavigationControllerOperation.push {
+            UIGraphicsBeginImageContextWithOptions((sourceView?.bounds.size)!, true, 0)
 
-            sourceView.drawViewHierarchyInRect(bounds, afterScreenUpdates: false)
+            sourceView?.drawHierarchy(in: bounds, afterScreenUpdates: false)
 
-            snapShot = UIGraphicsGetImageFromCurrentImageContext()
+            snapShot = UIGraphicsGetImageFromCurrentImageContext()!
 
             UIGraphicsEndImageContext()
 
-            let tempImageRef = snapShot.CGImage!
+            let tempImageRef = snapShot.cgImage!
             let imageSize = snapShot.size
             let imageScale = snapShot.scale
 
@@ -72,17 +72,18 @@ class SwiftyExpandingTransition: NSObject, UIViewControllerAnimatedTransitioning
                 bottomHeight = ((imageSize.height - self.selectedCellFrame.origin.y) * imageScale) + padding
             }
 
-            let topImageRect = CGRectMake(0, 0, imageSize.width * imageScale, topHeight)
+            let topImageRect = CGRect(x: 0, y: 0, width: imageSize.width * imageScale, height: topHeight)
 
-            let bottomImageRect = CGRectMake(0, topHeight, imageSize.width * imageScale, bottomHeight)
+            let bottomImageRect = CGRect(x: 0, y: topHeight, width: imageSize.width * imageScale, height: bottomHeight)
 
-            let topImageRef = CGImageCreateWithImageInRect(tempImageRef, topImageRect)!
-            let bottomImageRef = CGImageCreateWithImageInRect(tempImageRef, bottomImageRect)
+            let topImageRef = tempImageRef.cropping(to: topImageRect)!
+            let bottomImageRef = tempImageRef.cropping(to: bottomImageRect)
 
-            self.imageViewTop = UIImageView(image: UIImage(CGImage: topImageRef, scale: snapShot.scale, orientation: UIImageOrientation.Up))
+			self.imageViewTop = UIImageView(image: UIImage(cgImage: topImageRef, scale: snapShot.scale, orientation: UIImageOrientation.up))
+			
 
             if (bottomImageRef != nil) {
-                self.imageViewBottom = UIImageView(image: UIImage(CGImage: bottomImageRef!, scale: snapShot.scale, orientation: UIImageOrientation.Up))
+                self.imageViewBottom = UIImageView(image: UIImage(cgImage: bottomImageRef!, scale: snapShot.scale, orientation: UIImageOrientation.up))
             }
         }
 
@@ -91,9 +92,9 @@ class SwiftyExpandingTransition: NSObject, UIViewControllerAnimatedTransitioning
         var startFrameBottom = self.imageViewBottom!.frame
         var endFrameBottom = startFrameBottom
         // include any offset if view controllers are not initially at 0 y position
-        let yOffset = self.operation == UINavigationControllerOperation.Pop ? finalFrame.origin.y : initialFrame.origin.y
+        let yOffset = self.operation == UINavigationControllerOperation.pop ? finalFrame.origin.y : initialFrame.origin.y
 
-        if self.operation == UINavigationControllerOperation.Pop {
+        if self.operation == UINavigationControllerOperation.pop {
             startFrameTop.origin.y = -startFrameTop.size.height + yOffset
             endFrameTop.origin.y = yOffset
             startFrameBottom.origin.y = startFrameTop.height + startFrameBottom.height + yOffset
@@ -108,46 +109,45 @@ class SwiftyExpandingTransition: NSObject, UIViewControllerAnimatedTransitioning
         self.imageViewTop!.frame = startFrameTop
         self.imageViewBottom!.frame = startFrameBottom
 
-        destinationView.alpha = 0
-        sourceView.alpha = 0
+        destinationView?.alpha = 0
+        sourceView?.alpha = 0
 
         let backgroundView = UIView(frame: bounds)
-        backgroundView.backgroundColor = UIColor.blackColor()
-
-        if self.operation == UINavigationControllerOperation.Pop {
-            sourceView.alpha = 1
+        backgroundView.backgroundColor = UIColor.init(red: 153, green: 204, blue: 255, alpha: 1.0)
+        if self.operation == UINavigationControllerOperation.pop {
+            sourceView?.alpha = 1
 
             container.addSubview(backgroundView)
-            container.addSubview(sourceView)
-            container.addSubview(destinationView)
+            container.addSubview(sourceView!)
+            container.addSubview(destinationView!)
             container.addSubview(self.imageViewTop!)
             container.addSubview(self.imageViewBottom!)
 
-            UIView.animateWithDuration(transitionDuration(transitionContext), animations: { () -> Void in
+            UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: { () -> Void in
                 self.imageViewTop!.frame = endFrameTop
                 self.imageViewBottom!.frame = endFrameBottom
 
-                sourceView.alpha = 0
+                sourceView?.alpha = 0
 
                 }, completion: { (finish) -> Void in
                     self.imageViewTop!.removeFromSuperview()
                     self.imageViewBottom!.removeFromSuperview()
 
-                    destinationView.alpha = 1
+                    destinationView?.alpha = 1
                     transitionContext.completeTransition(true)
             })
 
         } else {
             container.addSubview(backgroundView)
-            container.addSubview(destinationView)
+            container.addSubview(destinationView!)
             container.addSubview(self.imageViewTop!)
             container.addSubview(self.imageViewBottom!)
 
-            UIView.animateWithDuration(transitionDuration(transitionContext), animations: { () -> Void in
+            UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: { () -> Void in
                 self.imageViewTop!.frame = endFrameTop
                 self.imageViewBottom!.frame = endFrameBottom
 
-                destinationView.alpha = 1
+                destinationView?.alpha = 1
 
                 }, completion: { (finish) -> Void in
                     self.imageViewTop!.removeFromSuperview()


### PR DESCRIPTION
I updated all the files to work with iOS 10 (Swift 3). I tested it on my iPhone 6s running iOS 10.0.2 and it ran as expected. 

In FontAwesome.swift, I removed 

```
dispatch_once(&Static.onceToken) {
    //other code here
}
```

as it has no direct replacement in Swift 3. I recommend finding a way to redo this if you wish to still have that feature again, but it works without it and the main point of this repo is the SwiftyExpandingTransition anyways. 